### PR TITLE
Train docker build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -5,3 +5,7 @@
 !mmdet/
 !requirements/
 !tools/
+
+.dockerignore
+docker-compose.yml
+Dockerfile

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+*
+
+!*.*
+!configs/
+!mmdet/
+!requirements/
+!tools/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,67 @@
+# ---------------------------------------------------------------
+# ---------------------- BUILD MMDET/MMCV ----------------------
+# ---------------------------------------------------------------
+# Based on mmdet official Dockerfile
+ARG PYTORCH_VERSION
+ARG CUDA_VERSION
+ARG CUDNN_VERSION
+FROM pytorch/pytorch:${PYTORCH_VERSION}-cuda${CUDA_VERSION}-cudnn${CUDNN_VERSION}-devel as built-mmdet
+
+ENV TORCH_CUDA_ARCH_LIST="6.0 6.1 7.0 7.5 8.0 8.6+PTX" \
+    TORCH_NVCC_FLAGS="-Xfatbin -compress-all" \
+    CMAKE_PREFIX_PATH="$(dirname $(which conda))/../" \
+    FORCE_CUDA="1" \
+		DEBIAN_FRONTEND=noninteractive
+
+# Avoid Public GPG key error
+# https://github.com/NVIDIA/nvidia-docker/issues/1631
+RUN rm /etc/apt/sources.list.d/cuda.list \
+    && apt-key del 7fa2af80 \
+    && apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64/3bf863cc.pub \
+    && apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/machine-learning/repos/ubuntu1804/x86_64/7fa2af80.pub
+
+# Install the required packages
+RUN apt-get update \
+    && apt-get install -y ffmpeg libsm6 libxext6 git ninja-build libglib2.0-0 libsm6 libxrender-dev libxext6 \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install MMEngine and MMCV
+RUN pip install openmim && \
+    mim install "mmengine>=0.7.1" "mmcv>=2.0.0rc4"
+
+# ------------------- (END) BUILD MMDET/MMCV --------------------
+
+# ---------------------------------------------------------------
+# --------------------- TRAIN ENVIRONNEMENT ---------------------
+# ---------------------------------------------------------------
+# Use of more lightweight image for development
+# as CUDA compilation should not be necessary
+FROM pytorch/pytorch:${PYTORCH_VERSION}-cuda${CUDA_VERSION}-cudnn${CUDNN_VERSION}-runtime AS train
+
+ENV SITE_PACKAGES="/opt/conda/lib/python3.10/site-packages"
+COPY --from=built-mmdet ${SITE_PACKAGES}/mmcv ${SITE_PACKAGES}/mmcv
+COPY --from=built-mmdet ${SITE_PACKAGES}/mmcv-2.0.1.dist-info ${SITE_PACKAGES}/mmcv-2.0.1.dist-info
+COPY --from=built-mmdet ${SITE_PACKAGES}/mmengine ${SITE_PACKAGES}/mmengine
+COPY --from=built-mmdet ${SITE_PACKAGES}/mmengine-0.8.4.dist-info ${SITE_PACKAGES}/mmengine-0.8.4.dist-info
+COPY --from=built-mmdet ${SITE_PACKAGES}/mim ${SITE_PACKAGES}/mim
+COPY --from=built-mmdet ${SITE_PACKAGES}/openmim-0.3.9.dist-info ${SITE_PACKAGES}/openmim-0.3.9.dist-info
+
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt-get update && \
+    apt-get install -y ffmpeg git ninja-build libglib2.0-0 libsm6 libxrender-dev libxext6 && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
+ENV PIP_ARGS="--no-cache-dir"
+RUN pip install ${PIP_ARGS} --upgrade pip mmpretrain
+RUN pip install ${PIP_ARGS} --upgrade --upgrade-strategy only-if-needed mmcv mmengine openmim
+RUN pip install ${PIP_ARGS} --upgrade pip setuptools
+
+
+COPY . .
+ARG COMMIT
+RUN echo "Training with commit: ${COMMIT}" && \
+    git checkout ${COMMIT} && \
+    pip install ${PIP_ARGS} .
+# ------------------- (END) DEV ENVIRONNEMENT --------------------

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@
 ARG PYTORCH_VERSION
 ARG CUDA_VERSION
 ARG CUDNN_VERSION
-FROM pytorch/pytorch:${PYTORCH_VERSION}-cuda${CUDA_VERSION}-cudnn${CUDNN_VERSION}-devel as built-mmdet
+FROM pytorch/pytorch:${PYTORCH_VERSION}-cuda${CUDA_VERSION}-cudnn${CUDNN_VERSION}-devel as build
 
 ENV TORCH_CUDA_ARCH_LIST="6.0 6.1 7.0 7.5 8.0 8.6+PTX" \
     TORCH_NVCC_FLAGS="-Xfatbin -compress-all" \
@@ -22,45 +22,53 @@ RUN rm /etc/apt/sources.list.d/cuda.list \
 
 # Install the required packages
 RUN apt-get update \
-    && apt-get install -y ffmpeg libsm6 libxext6 git ninja-build libglib2.0-0 libsm6 libxrender-dev libxext6 \
+    && apt-get install -y build-essential ffmpeg git ninja-build libglib2.0-0 libsm6 libxrender-dev libxext6 \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
 # Install MMEngine and MMCV
-RUN pip install --no-cache-dir --upgrade pip setuptools
-RUN pip install --no-cache-dir "mmengine>=0.7.1" "mmcv>=2.0.0rc4"
+ENV PIP_ARGS="--no-cache-dir"
+RUN pip install ${PIP_ARGS} --upgrade pip setuptools
+RUN pip install ${PIP_ARGS} "mmengine>=0.7.1" "mmcv>=2.0.0rc4"
 
+COPY . .
+ARG COMMIT
+RUN echo "Training with commit: ${COMMIT}" && \
+    git checkout --force ${COMMIT} && \
+    pip install --no-cache-dir -e .
 # ------------------- (END) BUILD MMDET/MMCV --------------------
+
 
 # ---------------------------------------------------------------
 # --------------------- TRAIN ENVIRONNEMENT ---------------------
 # ---------------------------------------------------------------
 # Use of more lightweight image for development
 # as CUDA compilation should not be necessary
-FROM pytorch/pytorch:${PYTORCH_VERSION}-cuda${CUDA_VERSION}-cudnn${CUDNN_VERSION}-runtime AS train
-
-ENV SITE_PACKAGES="/opt/conda/lib/python3.10/site-packages"
-COPY --from=built-mmdet ${SITE_PACKAGES}/mmcv ${SITE_PACKAGES}/mmcv
-COPY --from=built-mmdet ${SITE_PACKAGES}/mmcv-2.1.0.dist-info ${SITE_PACKAGES}/mmcv-2.1.0.dist-info
-COPY --from=built-mmdet ${SITE_PACKAGES}/mmengine ${SITE_PACKAGES}/mmengine
-COPY --from=built-mmdet ${SITE_PACKAGES}/mmengine-0.10.2.dist-info ${SITE_PACKAGES}/mmengine-0.10.2.dist-info
+FROM pytorch/pytorch:${PYTORCH_VERSION}-cuda${CUDA_VERSION}-cudnn${CUDNN_VERSION}-runtime AS base-runtime
 
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && \
-    apt-get install -y vim build-essential ffmpeg git ninja-build libglib2.0-0 libsm6 libxrender-dev libxext6 && \
-    apt-get clean && \
+    apt-get install -y git && \
+    apt-get clean &&  \
     rm -rf /var/lib/apt/lists/*
 
+COPY ./requirements.docker.txt .
 ENV PIP_ARGS="--no-cache-dir"
 RUN pip install ${PIP_ARGS} --upgrade pip setuptools && \
-		# Fix the missing deps caused by the COPY command.
-		# https://stackoverflow.com/questions/71496208/how-can-i-automatically-install-all-missing-dependencies-from-pip-check
-		pip check | sed -rn 's/.*requires ([^,]+),.*/\1/p' | xargs pip install
+		pip install ${PIP_ARGS} -r ./requirements.docker.txt
 
+# ---------------------------------------------------------------
+# ---------------------------------------------------------------
 
-COPY . .
-ARG COMMIT
-RUN echo "Training with commit: ${COMMIT}" && \
-    git checkout --force ${COMMIT} && \
-    pip install ${PIP_ARGS} -e .
-# ------------------- (END) DEV ENVIRONNEMENT --------------------
+FROM base-runtime AS runtime
+
+ENV SITE_PACKAGES="/opt/conda/lib/python3.10/site-packages"
+COPY --from=build ${SITE_PACKAGES}/mmcv ${SITE_PACKAGES}/mmcv
+COPY --from=build ${SITE_PACKAGES}/mmcv-2.1.0.dist-info ${SITE_PACKAGES}/mmcv-2.1.0.dist-info
+COPY --from=build ${SITE_PACKAGES}/mmengine ${SITE_PACKAGES}/mmengine
+COPY --from=build ${SITE_PACKAGES}/mmengine-0.10.2.dist-info ${SITE_PACKAGES}/mmengine-0.10.2.dist-info
+COPY --from=build ${SITE_PACKAGES}/mmdet.egg-link ${SITE_PACKAGES}/mmdet.egg-link
+COPY --from=build /workspace /workspace
+
+RUN pip install ${PIP_ARGS} -e . 
+# ------------------- (END) TRAIN ENVIRONNEMENT -----------------

--- a/Dockerfile
+++ b/Dockerfile
@@ -53,6 +53,7 @@ RUN apt-get update && \
 
 ENV PIP_ARGS="--no-cache-dir"
 RUN pip install ${PIP_ARGS} --upgrade pip setuptools && \
+		# Fix the missing deps caused by the COPY command.
 		# https://stackoverflow.com/questions/71496208/how-can-i-automatically-install-all-missing-dependencies-from-pip-check
 		pip check | sed -rn 's/.*requires ([^,]+),.*/\1/p' | xargs pip install
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -49,19 +49,17 @@ COPY --from=built-mmdet ${SITE_PACKAGES}/openmim-0.3.9.dist-info ${SITE_PACKAGES
 
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && \
-    apt-get install -y ffmpeg git ninja-build libglib2.0-0 libsm6 libxrender-dev libxext6 && \
+    apt-get install -y build-essential ffmpeg git ninja-build libglib2.0-0 libsm6 libxrender-dev libxext6 && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
 ENV PIP_ARGS="--no-cache-dir"
-RUN pip install ${PIP_ARGS} --upgrade pip mmpretrain
-RUN pip install ${PIP_ARGS} --upgrade --upgrade-strategy only-if-needed mmcv mmengine openmim
 RUN pip install ${PIP_ARGS} --upgrade pip setuptools
 
 
 COPY . .
 ARG COMMIT
 RUN echo "Training with commit: ${COMMIT}" && \
-    git checkout ${COMMIT} && \
+    git checkout --force ${COMMIT} && \
     pip install ${PIP_ARGS} .
 # ------------------- (END) DEV ENVIRONNEMENT --------------------

--- a/configs/_base_/datasets/cuhk_sysu.py
+++ b/configs/_base_/datasets/cuhk_sysu.py
@@ -43,7 +43,7 @@ train_dataloader = dict(
     dataset=dict(
         type=dataset_type,
         filter_cfg=dict(filter_empty_gt=False),
-        ann_file="annotations/annotations_sysu_train.json",
+        ann_file="annotations/annotations_train.json",
         data_root=data_root,
         pipeline=train_pipeline,
     ),

--- a/configs/_base_/datasets/cuhk_sysu.py
+++ b/configs/_base_/datasets/cuhk_sysu.py
@@ -37,8 +37,8 @@ train_pipeline = [
 
 train_dataloader = dict(
     shuffle=True,
-    batch_size=1,
-    num_workers=2,
+    batch_size=8,
+    num_workers=4,
     persistent_workers=True,
     dataset=dict(
         type=dataset_type,

--- a/configs/reid/detection/pstr_r50.py
+++ b/configs/reid/detection/pstr_r50.py
@@ -1,6 +1,6 @@
 _base_ = [
-    "/home/reusm/code/mmdet/configs/_base_/default_runtime.py",
-    "/home/reusm/code/mmdet/configs/_base_/datasets/cuhk_sysu.py",
+    "../../_base_/default_runtime.py",
+    "../../_base_/datasets/cuhk_sysu.py",
 ]
 
 detector = dict(

--- a/configs/reid/detection/pstr_r50.py
+++ b/configs/reid/detection/pstr_r50.py
@@ -100,7 +100,7 @@ reid = dict(  # PSTRHeadReID
             batch_first=True,
         ),
     ),
-    num_person=5532,
+    num_person=7792,
     flag_tri=True,
     queue_size=5000)
 

--- a/configs/reid/detection/pstr_r50.py
+++ b/configs/reid/detection/pstr_r50.py
@@ -149,7 +149,8 @@ param_scheduler = [
         end_factor=1,
         by_epoch=False,
         begin=0,
-        end=500,
+        end=63, # 500 // 8 (sysu batch size) + 1
+        # end=(500 // batch_size) + 1, # 500 samples ~= 500 / batch_size iterations
     ),
     # Epoch update
     dict(type='MultiStepLR', milestones=[19, 23], gamma=0.1)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,11 @@ services:
         # Fill with the correct commit of the repo
         # Set the SHA of the commit, ensure logging exact version of the repo
         COMMIT: ${COMMIT}
+    command: >
+      python tools/train.py 
+      configs/reid/detection/pstr_r50.py
+      --cfg-options
+      train_dataloader.dataset.data_root=/dataset/mmlab
     environment:
         TERM: 'screen-256color'
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,7 +18,6 @@ services:
 
     tty: true
     init: true
-    entrypoint: /entrypoint.sh
 
     volumes:
       - torch_cache:/root/.cache/torch

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ version: "3"
 services:
   train:
     build:
-      target: train
+      target: runtime
       context: .
       args:
         PYTORCH_VERSION: '2.0.1'
@@ -17,7 +17,8 @@ services:
       python tools/train.py 
       configs/reid/detection/pstr_r50.py
       --cfg-options
-      train_dataloader.dataset.data_root=/dataset/mmlab
+      train_dataloader.dataset.data_root=/dataset
+      train_dataloader.dataset.ann_file=annotations/annotations_train.json
     environment:
         TERM: 'screen-256color'
 
@@ -28,6 +29,7 @@ services:
       - torch_cache:/root/.cache/torch
       # Insert path of the root folder of the dataset
       - ${DATASET_PATH}:/dataset:ro
+      - ${OUTPUT_PATH}:/workspace/work_dirs
     shm_size: 16G
     deploy:
       resources:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,36 @@
+name: "mmdet-train"
+version: "3"
+
+services:
+  train:
+    build:
+      target: train
+      context: .
+      args:
+        PYTORCH_VERSION: '2.0.1'
+        CUDA_VERSION: '11.7'
+        CUDNN_VERSION: '8'
+        # Fill with the correct commit of the repo
+        # Set the SHA of the commit, ensure logging exact version of the repo
+        COMMIT: ${COMMIT}
+    environment:
+        TERM: 'screen-256color'
+
+    tty: true
+    init: true
+    entrypoint: /entrypoint.sh
+
+    volumes:
+      - torch_cache:/root/.cache/torch
+      # Insert path of the root folder of the dataset
+      - ${DATASET_PATH}:/dataset:ro
+    shm_size: 16G
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              capabilities: [ gpu ]
+
+volumes:
+  torch_cache:

--- a/mmdet/models/reid_heads/pstr_reid.py
+++ b/mmdet/models/reid_heads/pstr_reid.py
@@ -279,7 +279,7 @@ class PSTRHeadReID(BaseModel):
         loss_oim = self.oim_weight_single_scale_layer * F.nll_loss(
             focal_probabilities,
             only_assigned_person_ids,
-            reduction="none",
+            reduction="sum",
             ignore_index=-1)
 
         if not self.flag_tri:

--- a/requirements.docker.txt
+++ b/requirements.docker.txt
@@ -1,0 +1,16 @@
+terminaltables
+opencv-python-headless
+shapely
+scipy
+pycocotools
+matplotlib
+python-dateutil
+pyparsing
+kiwisolver
+fonttools
+cycler
+contourpy
+yapf
+addict
+rich
+termcolor


### PR DESCRIPTION
Add a Dockerfile to build a training image including a specific commit of the repo.* The image is a multi-stage build, one base image using the devel torch base image and another one using runtime for actual training. It uses a `requirements.docker.txt` and a `.dockerignore` file for building.

We add a `docker-compose.yml` and some variable in `.env` to set up the runtime of the training (volumes) and some build args. This compose file should be freely modified to make the training run locally or on a remote cluster.

Quick fix of the handling of the batch size. The implementation is still a loop for each sample. It can be improved by computing the reid loss with "vectorized" version across samples.

Quick fix the number of persons in the dataset. 


*: couple the repo version and the image to ensure that everything is in one place. Thus, it enhances reproducibility. 